### PR TITLE
Enhancements to support ReaxFF

### DIFF
--- a/.github/workflows/BranchCI.yaml
+++ b/.github/workflows/BranchCI.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   light-ci:
-    name: Lint ubuntu-latest Py3.8
+    name: Lint ubuntu-latest Py3.9
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -23,7 +23,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         environment-file: devtools/conda-envs/test_env.yaml
         activate-environment: test
         auto-update-conda: false
@@ -49,7 +49,7 @@ jobs:
       with:
         file: ./coverage.xml
         flags: unittests
-        name: codecov-ubuntu-latest-py3.8
+        name: codecov-ubuntu-latest-py3.9
     - name: Build documentation
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   lint-docs:
-    name: Lint-Docs ubuntu-latest Py3.8
+    name: Lint-Docs ubuntu-latest Py3.9
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -32,7 +32,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         environment-file: devtools/conda-envs/test_env.yaml
         activate-environment: test
         auto-update-conda: false
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Additional info about the build

--- a/.github/workflows/Docs.yaml
+++ b/.github/workflows/Docs.yaml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
   docs:
-    name: Docs ubuntu-latest Py3.8
+    name: Docs ubuntu-latest Py3.9
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -20,7 +20,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         environment-file: devtools/conda-envs/test_env.yaml
         activate-environment: test
         auto-update-conda: false

--- a/.github/workflows/Release.yaml
+++ b/.github/workflows/Release.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-docs:
-    name: Lint-Docs ubuntu-latest Py3.8
+    name: Lint-Docs ubuntu-latest Py3.9
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -24,7 +24,7 @@ jobs:
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
         environment-file: devtools/conda-envs/test_env.yaml
         activate-environment: test
         auto-update-conda: false
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.8, 3.9]
     steps:
     - uses: actions/checkout@v1
     - name: Additional info about the build
@@ -82,7 +82,7 @@ jobs:
         name: codecov-${{ matrix.os }}-py${{ matrix.python-version }}
 
   deploy:
-    name: PyPi ubuntu-latest Py3.8
+    name: PyPi ubuntu-latest Py3.9
     # Run only for tagged releases publishing development or release candidates
     # only to test.pypi, otherwise to both it and the main pypi.
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags')
@@ -90,10 +90,10 @@ jobs:
     needs: [lint-docs, test]
     steps:
     - uses: actions/checkout@v1
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install package
       shell: bash -l {0}
       run: |

--- a/molsystem/atoms.py
+++ b/molsystem/atoms.py
@@ -5,6 +5,7 @@
 
 from itertools import zip_longest
 import logging
+import pprint  # noqa: F401
 from typing import Any, Dict, TypeVar
 
 import numpy
@@ -634,7 +635,7 @@ class _Atoms(_Table):
             molecules = self.configuration.find_molecules(as_indices=True)
 
             for indices in molecules:
-                indices = numpy.array([i - 1 for i in indices])
+                indices = numpy.array(indices)
                 uvw_mol = numpy.take(UVW, indices, axis=0)
                 center = numpy.average(uvw_mol, axis=0)
                 delta = numpy.floor(center)

--- a/molsystem/cif.py
+++ b/molsystem/cif.py
@@ -309,23 +309,23 @@ class CIFMixin:
             cell = self.cell
             a, b, c, alpha, beta, gamma = cell.parameters
             volume = cell.volume
-            lines.append("_symmetry_space_group_name_H-M   'P 1'")
-            lines.append(f"_cell_length_a   {a}")
-            lines.append(f"_cell_length_b   {b}")
-            lines.append(f"_cell_length_c   {c}")
-            lines.append(f"_cell_angle_alpha   {alpha}")
-            lines.append(f"_cell_angle_beta    {beta}")
-            lines.append(f"_cell_angle_gamma   {gamma}")
-            lines.append("_symmetry_Int_Tables_number   1")
-            lines.append(f"_cell_volume   {volume}")
-            lines.append(f"_cell_formula_units_Z   {Z}")
-            lines.append("loop_")
-            lines.append(" _symmetry_equiv_pos_site_id")
-            lines.append(" _symmetry_equiv_pos_as_xyz")
-            lines.append("  1  'x, y, z'")
+            # lines.append("_symmetry_space_group_name_H-M   'P 1'")
+            lines.append(f"_cell.length_a   {a}")
+            lines.append(f"_cell.length_b   {b}")
+            lines.append(f"_cell.length_c   {c}")
+            lines.append(f"_cell.angle_alpha   {alpha}")
+            lines.append(f"_cell.angle_beta    {beta}")
+            lines.append(f"_cell.angle_gamma   {gamma}")
+            # lines.append("_symmetry_Int_Tables_number   1")
+            lines.append(f"_cell.volume   {volume}")
+            lines.append(f"_cell.formula_units_Z   {Z}")
+            # lines.append("loop_")
+            # lines.append(" _symmetry_equiv_pos_site_id")
+            # lines.append(" _symmetry_equiv_pos_as_xyz")
+            # lines.append("  1  'x, y, z'")
 
-        lines.append(f"_chemical_formula_structural   '{empirical_formula}'")
-        lines.append(f"_chemical_formula_sum   '{formula}'")
+        # lines.append(f"_chemical_formula_structural   '{empirical_formula}'")
+        lines.append(f"_chemical_formula.sum   '{formula}'")
 
         # The atoms
         lines.append("loop_")
@@ -357,8 +357,9 @@ class CIFMixin:
                 tmp[name] = 1
                 names.append(name)
 
-        XYZ = atoms.get_coordinates(in_cell="molecule")
+        XYZ = atoms.get_coordinates(in_cell="molecule", fractionals=False)
         XYZa = atoms.get_coordinates(fractionals=False)
+        XYZa = XYZ
 
         symbols = atoms.symbols
         for element, name, xyza, xyz in zip(symbols, names, XYZa, XYZ):

--- a/molsystem/configuration.py
+++ b/molsystem/configuration.py
@@ -79,19 +79,39 @@ class _Configuration(
             self.cursor.execute(
                 "SELECT atomset FROM configuration WHERE id = ?", (self.id,)
             )
-            tmp = self.cursor.fetchone()
-            # atomset = self.cursor.fetchone()[0]
-            atomset = tmp[0]
-            if atomset is None:
-                # No atomset, so create one and update this configuration
-                atomset = self.system_db["atomset"].append(n=1)[0]
-                self.db.execute(
-                    "UPDATE configuration SET atomset = ? WHERE id = ?",
-                    (atomset, self.id),
-                )
-                self.db.commit()
-            self._atomset = atomset
+            self._atomset = self.cursor.fetchone()[0]
+        if self._atomset is None:
+            # No atomset, so create one and update this configuration
+            self._atomset = self.system_db["atomset"].append(n=1)[0]
+            self.db.execute(
+                "UPDATE configuration SET atomset = ? WHERE id = ?",
+                (self._atomset, self.id),
+            )
+            self.db.commit()
         return self._atomset
+
+    @atomset.setter
+    def atomset(self, value):
+        if self._atomset is None:
+            # Cache the atomset for this configuration
+            self.cursor.execute(
+                "SELECT atomset FROM configuration WHERE id = ?", (self.id,)
+            )
+            tmp = self.cursor.fetchone()
+            self._atomset = tmp[0]
+        if self._atomset is None:
+            # No atomset, so update this configuration
+            self.db.execute(
+                "UPDATE configuration SET atomset = ? WHERE id = ?",
+                (value, self.id),
+            )
+            self.db.commit()
+            self._atomset = value
+        elif value == self._atomset:
+            # Do nothing
+            pass
+        else:
+            raise RuntimeError("The atomset is already set!")
 
     @property
     def bonds(self):
@@ -106,17 +126,38 @@ class _Configuration(
             self.cursor.execute(
                 "SELECT bondset FROM configuration WHERE id = ?", (self.id,)
             )
-            bondset = self.cursor.fetchone()[0]
-            if bondset is None:
-                # No bondset, so create one and update this configuration
-                bondset = self.system_db["bondset"].append(n=1)[0]
-                self.db.execute(
-                    "UPDATE configuration SET bondset = ? WHERE id = ?",
-                    (bondset, self.id),
-                )
-                self.db.commit()
-            self._bondset = bondset
+            self._bondset = self.cursor.fetchone()[0]
+        if self._bondset is None:
+            # No bondset, so create one and update this configuration
+            self._bondset = self.system_db["bondset"].append(n=1)[0]
+            self.db.execute(
+                "UPDATE configuration SET bondset = ? WHERE id = ?",
+                (self._bondset, self.id),
+            )
+            self.db.commit()
         return self._bondset
+
+    @bondset.setter
+    def bondset(self, value):
+        if self._bondset is None:
+            # Cache the bondset for this configuration
+            self.cursor.execute(
+                "SELECT bondset FROM configuration WHERE id = ?", (self.id,)
+            )
+            self._bondset = self.cursor.fetchone()[0]
+        if self._bondset is None:
+            # No bondset, so update this configuration
+            self.db.execute(
+                "UPDATE configuration SET bondset = ? WHERE id = ?",
+                (value, self.id),
+            )
+            self.db.commit()
+            self._bondset = value
+        elif value == self._bondset:
+            # No change
+            pass
+        else:
+            raise RuntimeError("The bondset is already set!")
 
     @property
     def cell(self):

--- a/molsystem/subsets.py
+++ b/molsystem/subsets.py
@@ -208,3 +208,28 @@ class _Subsets(_Table):
            AND configuration = ?
         """
         return [x[0] for x in self.db.execute(sql, (tid, self._cid))]
+
+    def get_counts(self, configuration="all"):
+        """Get the counts of subsets per template for configurations.
+
+        Parameters
+        ----------
+        configuration : int or MolSystem._Configuration or "all"
+            The configuration, as an object or its id, or "all" for all
+            configurations. Default is "all".
+
+        Returns
+        -------
+        [[configuration_id, name, count]]
+        """
+
+        if configuration == "all":
+            sql = (
+                "SELECT subset.configuration, name, count(1) FROM subset, template "
+                " WHERE template = template.id "
+                " GROUP BY subset.configuration, name "
+                " ORDER BY subset.configuration"
+            )
+            return [[*x] for x in self.db.execute(sql)]
+        else:
+            raise NotImplementedError("get_counts only take 'all' configurations")

--- a/molsystem/system.py
+++ b/molsystem/system.py
@@ -332,7 +332,7 @@ class _System(CIFMixin, MutableMapping):
         periodicity=0,
         coordinatesystem=None,
         symmetry=None,
-        cell=None,
+        cell_id=None,
         atomset=None,
         bondset=None,
         make_current=True,
@@ -350,8 +350,8 @@ class _System(CIFMixin, MutableMapping):
             Defaults to Cartesian for molecules and fractional for crystals.
         symmetry : int or str = None
             The id or name of the point or space group (optional)
-        cell : Cell or 6-vector = None
-            The cell parameters, default to last ones.
+        cell_id : int = None
+            The id of the _Cell object
         atomset : int = None
             The set of atoms in this configurationn
         bondset : int = None
@@ -377,8 +377,8 @@ class _System(CIFMixin, MutableMapping):
                     kwargs["coordinatesystem"] = "fractional"
         if symmetry is not None:
             kwargs["symmetry"] = symmetry
-        if cell is not None:
-            kwargs["cell"] = cell
+        if cell_id is not None:
+            kwargs["cell"] = cell_id
         if atomset is not None:
             kwargs["atomset"] = atomset
         if bondset is not None:

--- a/molsystem/system_db.py
+++ b/molsystem/system_db.py
@@ -607,6 +607,46 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
 
         return result
 
+    def find_configurations(self, atomset=None, bondset=None):
+        """Return the configurations that have given atom- or bondsets
+
+        Parameters
+        ----------
+        atomset : int = None
+            The id of the atomset.
+        bondset : int = None
+            The id of the bondset.
+
+        Returns
+        -------
+        [_Configuration]
+        """
+
+        if atomset is not None:
+            if bondset is not None:
+                self.cursor.execute(
+                    "SELECT id FROM configuration WHERE atomset = ? AND bondset = ?",
+                    (atomset, bondset),
+                )
+            else:
+                self.cursor.execute(
+                    "SELECT id FROM configuration WHERE atomset = ?", (atomset,)
+                )
+            return [
+                _Configuration(_id=cid, system_db=self)
+                for cid in self.cursor.fetchall()
+            ]
+        elif bondset is not None:
+            self.cursor.execute(
+                "SELECT id FROM configuration WHERE bondset = ?", (bondset,)
+            )
+            return [
+                _Configuration(_id=cid, system_db=self)
+                for cid in self.cursor.fetchall()
+            ]
+        else:
+            raise RuntimeError("Must give atomset or bondset.")
+
     def get_configuration(self, cid):
         """Return the specified configuration.
 

--- a/molsystem/system_db.py
+++ b/molsystem/system_db.py
@@ -788,6 +788,10 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
             table = self["atomset_atom"]
             table.add_attribute("atomset", coltype="int", references="atomset")
             table.add_attribute("atom", coltype="int", references="atom")
+            self.db.execute(
+                "CREATE INDEX 'idx_atomset_atom_atomset_atom' "
+                'ON atomset_atom ("atomset", "atom")'
+            )
 
             # The bonds, and sets of bonds
             table = self["bond"]
@@ -795,6 +799,10 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
             table.add_attribute("i", coltype="int", references="atom")
             table.add_attribute("j", coltype="int", references="atom")
             table.add_attribute("bondorder", coltype="int", default=1)
+            # Only need for infinite networked systems. Think about later!
+            # table.add_attribute("offset1", coltype="int", default=0)
+            # table.add_attribute("offset2", coltype="int", default=0)
+            # table.add_attribute("offset3", coltype="int", default=0)
 
             table = self["bondset"]
             table.add_attribute("id", coltype="int", pk=True)
@@ -802,6 +810,10 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
             table = self["bondset_bond"]
             table.add_attribute("bondset", coltype="int", references="bondset")
             table.add_attribute("bond", coltype="int", references="bond")
+            self.db.execute(
+                "CREATE INDEX 'idx_bondset_bond_bondset_bond' "
+                'ON bondset_bond ("bondset", "bond")'
+            )
 
             # Now we can set up the configurations
             table = self["configuration"]
@@ -825,7 +837,13 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
             table.add_attribute("x", coltype="float")
             table.add_attribute("y", coltype="float")
             table.add_attribute("z", coltype="float")
-
+            self.db.execute(
+                "CREATE INDEX 'idx_coordinates_atom' ON coordinates (\"atom\")"
+            )
+            self.db.execute(
+                "CREATE INDEX idx_coordinates_atom_configuration "
+                "    ON coordinates(atom, configuration)"
+            )
             # The definition of the subsets -- templates
             table = self["template"]
             table.add_attribute("id", coltype="int", pk=True)
@@ -847,12 +865,20 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
                 "configuration", coltype="int", references="configuration"
             )
             table.add_attribute("template", coltype="int", references="template")
+            self.db.execute(
+                "CREATE INDEX subset_idx_template_configuration "
+                "ON subset(template, configuration)"
+            )
 
             # The connection between subsets and the atoms in the system
             table = self["subset_atom"]
             table.add_attribute("atom", coltype="int", references="atom")
             table.add_attribute("subset", coltype="int", references="subset")
             table.add_attribute("templateatom", coltype="int", references="atom")
+            self.db.execute(
+                "CREATE INDEX 'idx_subset_atom_subset_atom' "
+                'ON subset_atom ("subset", "atom")'
+            )
 
             self.db.commit()
 

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
         'Natural Language :: English',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ]
 )

--- a/tests/test_cif.py
+++ b/tests/test_cif.py
@@ -265,8 +265,7 @@ data_CH2O
 _chem_comp.name 'C2 H4 O2'
 _chem_comp.id 'CH2O'
 _chem_comp.formula   'C2 H4 O2'
-_chemical_formula_structural   'C H2 O'
-_chemical_formula_sum   'C2 H4 O2'
+_chemical_formula.sum   'C2 H4 O2'
 loop_
  _chem_comp_atom.comp_id
  _chem_comp_atom.atom_id


### PR DESCRIPTION
A number of enhancements and bug fixes needed when implementing the ReaxFF modules.

- Allow changing the atomset and bondset in a configuration before they are created by default. This allows sharing them between different configurations.
- Added optimized method to return counts of subsets for all templates.
- Added database indexes to improve performance for common queries.
- Fixed issue creating a configuration with a given unit cell.
- Fixed issues with coordinate handling when configurations share an atomset.
- Fixed issues with creating templates from non-contiguous atoms in a system.