### PR TITLE
Improved database write performance.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,6 @@
 History
 =======
 
-0.1.0 (2019-05-05)
-------------------
-
-* First release on PyPI.
+2022.10.26 -- Improved database write performance.
+  Switched to write-ahead mode and tweaked memory settings. This gives a large
+  performance improvement (10x or more) for large database (~1 GB).

--- a/molsystem/system_db.py
+++ b/molsystem/system_db.py
@@ -352,6 +352,10 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
                 self._db = sqlite3.connect(self._filename)
             self._db.row_factory = sqlite3.Row
             self._db.execute("PRAGMA foreign_keys = ON")
+            self._db.execute("PRAGMA journal_mode = WAL")
+            self._db.execute("PRAGMA synchronous = normal")
+            self._db.execute("PRAGMA temp_store = memory")
+            self._db.execute("PRAGMA mmap_size = 30000000000")
             self._cursor = self._db.cursor()
             self._initialize()
 


### PR DESCRIPTION
  Switched to write-ahead mode and tweaked memory settings. This gives a large performance improvement (10x or more) for large database (~1 GB).
