### PR TITLE
Bugfix: bonds in RDKit

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - "main"
+  workflow_dispatch:
+
 
 jobs:
   ci:

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,7 +1,11 @@
 =======
 History
 =======
-2023.4.6 -- Added gradients
+2024.5.5 -- Bugfix: bonds in RDKit
+    * There was an indexing bug translating bonds back from RDKit to SEAMM. The famous
+      0/1 problem!
+      
+2024.4.6 -- Added gradients
     * Added gradient on atoms as a separate table alongside atoms, so they take no space
       unless actually used.
       

--- a/molsystem/properties.py
+++ b/molsystem/properties.py
@@ -254,7 +254,7 @@ class _Properties(object):
         )
         self.db.execute("CREATE INDEX str_data_idx_system ON str_data(system)")
 
-        # Integer facts
+        # Array facts
         table = self.system_db["json_data"]
         table.add_attribute("id", coltype="int", pk=True)
         table.add_attribute("configuration", coltype="int", references="configuration")

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -13,6 +13,7 @@ except ModuleNotFoundError:
     raise
 
 logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
 
 # Valence
 valence = {
@@ -119,8 +120,8 @@ class RDKitMixin:
 
         self.clear()
         ids = self.atoms.append(x=Xs, y=Ys, z=Zs, atno=atnos)
-        i = [ids[x - 1] for x in Is]
-        j = [ids[x - 1] for x in Js]
+        i = [ids[x] for x in Is]
+        j = [ids[x] for x in Js]
         self.bonds.append(i=i, j=j, bondorder=BondOrders)
 
         return self


### PR DESCRIPTION
* There was an indexing bug translating bonds back from RDKit to SEAMM. The famous 0/1 problem!