### PR TITLE
Bugfix: creating H2 from SMILES failed

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2024.8.5 -- Bugfix: creating H2 from SMILES failed
+    * Fixed bug where creating molecules consisting of just hydrogen failed because
+      RDKit by default ignores all hydrogens when reorienting the molecule.
+
 2024.6.21 -- Switching default for SMILES to RDKit rather than OpenBabel
     * RDKit seems more robust, and also the atom typing uses RDkit, so compatibility is
       important.

--- a/molsystem/smiles.py
+++ b/molsystem/smiles.py
@@ -142,7 +142,7 @@ class SMILESMixin:
         if reorient:
             rdkMol = self.to_RDKMol()
             rdkConf = rdkMol.GetConformers()[0]
-            Chem.rdMolTransforms.CanonicalizeConformer(rdkConf)
+            Chem.rdMolTransforms.CanonicalizeConformer(rdkConf, ignoreHs=False)
             self.from_RDKMol(rdkMol)
 
         if name is not None:


### PR DESCRIPTION
* Fixed bug where creating molecules consisting of just hydrogen failed because RDKit by default ignores all hydrogens when reorienting the molecule.