### PR TITLE
Added units to properties in Openbabel molecules

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2024.11.12 -- Added units to properties in Openbabel molecules
+    * Any properties on the system and configuration are optionally added to the
+      Openbabel Molecule object for e.g. writing to an SDF file. This adds the units of
+      the properties explicitly
+      
 2024.10.1 -- Bugfix: Incorrect coordinates from PubChem
     * Fixed bug where the coordinates from PubChem were accidentally the 2-D rather than
       3-D coordinates.

--- a/molsystem/openbabel.py
+++ b/molsystem/openbabel.py
@@ -69,6 +69,12 @@ class OpenBabelMixin:
                 pair.SetValue(str(value))
                 ob_mol.CloneData(pair)
 
+                # Units, if any
+                units = self.properties.units(key)
+                if units is not None and units != "":
+                    pair.SetAttribute(key + ",units")
+                    pair.SetValue(units)
+                    ob_mol.CloneData(pair)
         return ob_mol
 
     def from_OBMol(

--- a/molsystem/openbabel.py
+++ b/molsystem/openbabel.py
@@ -72,7 +72,11 @@ class OpenBabelMixin:
                 # Units, if any
                 units = self.properties.units(key)
                 if units is not None and units != "":
-                    pair.SetAttribute(key + ",units")
+                    tmp = key.split("#", maxsplit=1)
+                    if len(tmp) > 1:
+                        pair.SetAttribute(tmp[0] + ",units" + "#" + tmp[1])
+                    else:
+                        pair.SetAttribute(key + ",units")
                     pair.SetValue(units)
                     ob_mol.CloneData(pair)
         return ob_mol


### PR DESCRIPTION
* Any properties on the system and configuration are optionally added to the Openbabel Molecule object for e.g. writing to an SDF file. This adds the units of the properties explicitly