### PR TITLE
Bugfix: error with charge and multiplicity

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2024.11.27 -- Bugfix: error with charge and multiplicity
+    * The charge and multiplicity of the system were not correctly set when creating a
+      system from a SMILES string using RDKit. More generally, the charge and
+      multiplicity were not correctly set from an RDKit molecule unless explicitly given
+      in the properties.
+    
 2024.11.23 -- Bugfix: error if OpenEye not available
     * Fixed an issue with the import of OpenEye that caused an error if OpenEye was not
       available.

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -55,7 +55,8 @@ class RDKitMixin:
         indices = []
         rdk_mol = Chem.RWMol()
         for atno, _id in zip(self.atoms.atomic_numbers, self.atoms.ids):
-            idx = rdk_mol.AddAtom(Chem.Atom(atno))
+            atom = Chem.Atom(atno)
+            idx = rdk_mol.AddAtom(atom)
             index[_id] = idx
             indices.append(idx)
 
@@ -198,6 +199,15 @@ class RDKitMixin:
 
         data = rdk_mol.GetPropsAsDict()
         if self.__class__.__name__ == "_Configuration":
+            # Charge
+            self.charge = int(Chem.GetFormalCharge(rdk_mol))
+
+            # Calculate spin multiplicity assuming maximal spin
+            n_electrons = 0
+            for rdk_atom in rdk_mol.GetAtoms():
+                n_electrons += rdk_atom.GetNumRadicalElectrons()
+            self.spin_multiplicity = n_electrons + 1
+
             # Check for property items for charge and multiplicity
             if "net charge" in data:
                 self.charge = int(data["net charge"])


### PR DESCRIPTION
* The charge and multiplicity of the system were not correctly set when creating a system from a SMILES string using RDKit. More generally, the charge and multiplicity were not correctly set from an RDKit molecule unless explicitly given in the properties.