### PR TITLE
Bugfix: Properties in SDF files

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2024.12.11 -- Bugfix: Properties in SDF files
+    * Transferring properties to the Open Babel and RDKit molecules was incorrect after
+      recent changes to the handling of properties. This fixes the problem, and now SDF
+      files have the properties correctly.
+      
 2024.12.7 -- Significant internal enhancement to property handling.
     * An internal change, allowing listing and getting properties with wildcards,
       working with multiple values at once. This is a significant change, but should

--- a/molsystem/openbabel.py
+++ b/molsystem/openbabel.py
@@ -81,6 +81,7 @@ class OpenBabelMixin:
         if properties is not None:
             data = self.properties.get(properties, include_system_properties=True)
             for key, value in data.items():
+                value = value["value"]
                 pair.SetAttribute(key)
                 pair.SetValue(str(value))
                 ob_mol.CloneData(pair)

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -103,6 +103,7 @@ class RDKitMixin:
         if properties is not None:
             data = self.properties.get(properties, include_system_properties=True)
             for key, value in data.items():
+                value = value["value"]
                 if isinstance(value, int):
                     rdk_mol.SetIntProp(key, value)
                 elif isinstance(value, float):

--- a/tests/test_openbabel.py
+++ b/tests/test_openbabel.py
@@ -501,12 +501,12 @@ def test_all_residue_search(configuration):
 def test_to_OBMol(Acetate):
     """Test creating an OBMol object from a structure."""
     correct = {
-        "float property": "{'sid': 1, 'cid': 1, 'value': 3.14}",
+        "float property": 3.14,
         "float property,units": "kcal/mol",
-        "int property": "{'sid': 1, 'cid': 1, 'value': 2}",
+        "int property": 2,
         "net charge": -1,
         "spin multiplicity": 1,
-        "str property": "{'sid': 1, 'cid': 1, 'value': 'Hi!'}",
+        "str property": "Hi!",
     }
 
     mol = Acetate.to_OBMol(properties="*")

--- a/tests/test_rdkit.py
+++ b/tests/test_rdkit.py
@@ -20,12 +20,12 @@ def test_version():
 def test_to_RDKMol(Acetate):
     """Test creating a RDKMol object from a structure."""
     correct = {
-        "float property": "{'sid': 1, 'cid': 1, 'value': 3.14}",
+        "float property": 3.14,
         "float property,units": "kcal/mol",
-        "int property": "{'sid': 1, 'cid': 1, 'value': 2}",
+        "int property": 2,
         "net charge": -1,
         "spin multiplicity": 1,
-        "str property": "{'sid': 1, 'cid': 1, 'value': 'Hi!'}",
+        "str property": "Hi!",
     }
 
     mol = Acetate.to_RDKMol(properties="*")


### PR DESCRIPTION
* Transferring properties to the Open Babel and RDKit molecules was incorrect after recent changes to the handling of properties. This fixes the problem, and now SDF files have the properties correctly.