### PR TITLE
Bugfix: Error if system or configuration name is None

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,10 @@
 =======
 History
 =======
+2025.3.16 -- Bugfix: Error if system of configuration name is None
+    * This fixes an error in toRDKMol and toOBMol when the system or configuration name
+      is None.
+      
 2025.3.4 -- Generalized the alignment/RMSD code
     * Generalized the alignment/RMSD code to make it easier to do berofe and after
       comparisons in optimizations and similar applications.

--- a/molsystem/openbabel.py
+++ b/molsystem/openbabel.py
@@ -89,13 +89,15 @@ class OpenBabelMixin:
             ob_mol.CloneData(pair)
 
             # Add the system and configuration names.
-            pair.SetAttribute("SEAMM|system name|str|")
-            pair.SetValue(self.system.name)
-            ob_mol.CloneData(pair)
+            if self.system.name is not None:
+                pair.SetAttribute("SEAMM|system name|str|")
+                pair.SetValue(self.system.name)
+                ob_mol.CloneData(pair)
 
-            pair.SetAttribute("SEAMM|configuration name|str|")
-            pair.SetValue(self.name)
-            ob_mol.CloneData(pair)
+            if self.name is not None:
+                pair.SetAttribute("SEAMM|configuration name|str|")
+                pair.SetValue(self.name)
+                ob_mol.CloneData(pair)
 
         if properties is not None:
             data = self.properties.get(properties, include_system_properties=True)

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -106,8 +106,10 @@ class RDKitMixin:
                 "SEAMM|XYZ|json|",
                 json.dumps(self.coordinates, indent=4, cls=CompactJSONEncoder),
             )
-            rdk_mol.SetProp("SEAMM|system name|str|", self.system.name)
-            rdk_mol.SetProp("SEAMM|configuration name|str|", self.name)
+            if self.system.name is not None:
+                rdk_mol.SetProp("SEAMM|system name|str|", self.system.name)
+            if self.name is not None:
+                rdk_mol.SetProp("SEAMM|configuration name|str|", self.name)
 
         if properties is not None:
             data = self.properties.get(properties, include_system_properties=True)

--- a/tests/test_openbabel.py
+++ b/tests/test_openbabel.py
@@ -436,7 +436,7 @@ def test_substructure_ordering(disordered):
     assert result == answer2
 
     # With hydrogens
-    smiles = templates[0].to_smiles(hydrogens=True)
+    smiles = templates[0].to_smiles(hydrogens=True, flavor="openbabel")
     if smiles != answer3:
         pprint.pprint(smiles)
     assert smiles == answer3


### PR DESCRIPTION
* This fixes an error in to_RDKMol and to_OBMol when the system or configuration name is None.