### PR TITLE
Enhancement to OpenBabel/SDF to handle periodic systems

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 =======
 History
 =======
+2025.4.1 -- Enhancement to OpenBabel/SDF to handle periodic systems
+    * Enhanced the OpenBabel molecule interface to handle periodic systems better, which
+      in turn supports using SDF files for periodic systems using SEAMM-specific
+      customization. The coordinates are always stored as Cartesians, and the cell
+      information is added as a property, and used when reading periodic systems written
+      by SEAMM.
+    * Added code to the RDKit interface to allow setting/getting just the coordinates
+      to/from a RDKit Molecule object. This is in analogy to the implementation in
+      OpenBabel.
+    * Added code to truncate near zero coordinates and cell parameters (< 1.0e-6) to make
+      coordinates and the cell parameters easier to read.
+      
 2025.3.16 -- Bugfix: Error if system of configuration name is None
     * This fixes an error in toRDKMol and toOBMol when the system or configuration name
       is None.

--- a/molsystem/atoms.py
+++ b/molsystem/atoms.py
@@ -1260,7 +1260,14 @@ class _Atoms(_Table):
         vxs = self.get_column_data("vx")
         vys = self.get_column_data("vy")
         vzs = self.get_column_data("vz")
-        xyz = [[vx, vy, vz] for vx, vy, vz in zip(vxs, vys, vzs)]
+        xyz = [
+            [
+                vx if abs(vx) > 1.0e-6 else 0,
+                vy if abs(vy) > 1.0e-6 else 0,
+                vz if abs(vz) > 1.0e-6 else 0,
+            ]
+            for vx, vy, vz in zip(vxs, vys, vzs)
+        ]
 
         periodicity = self.configuration.periodicity
         if periodicity == 0:

--- a/molsystem/cell.py
+++ b/molsystem/cell.py
@@ -272,6 +272,7 @@ class Cell(object):
         T = self.to_cartesians_transform(as_array=True)
         XYZ = UVW @ T
 
+        XYZ[numpy.abs(XYZ) < 1.0e-6] = 0
         if as_array:
             return XYZ
         else:
@@ -311,10 +312,12 @@ class Cell(object):
             [c * cb, c * (ca - cb * cg) / sg, V / (a * b * sg)],
         ]  # yapf: disable
 
+        T = numpy.array(T)
+        T[numpy.abs(T) < 1.0e-6] = 0
         if as_array:
-            return numpy.array(T)
-        else:
             return T
+        else:
+            return T.tolist()
 
     def to_fractionals(self, xyz, as_array=False):
         """Convert Cartesian coordinates to fractional.

--- a/molsystem/properties.py
+++ b/molsystem/properties.py
@@ -38,7 +38,6 @@ def add_properties_from_file(path):
     that it is indeed the same, it can be replaced by the standard form, and also
     aliased to it for backwards compatibility.
     """
-    global standard_properties
     with open(path, newline="", encoding="utf-8-sig") as fd:
         data = csv.reader(fd)
         line = 0
@@ -87,7 +86,6 @@ class _Properties(object):
 
     @property
     def standard_properties(self):
-        global standard_properties
         return standard_properties
 
     @property

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -52,6 +52,28 @@ def rdkit_version():
 class RDKitMixin:
     """A mixin for handling RDKit via its Python interface."""
 
+    def coordinates_from_RDKMol(self, rdkmol):
+        """Update the coordinates from an RDKMol.
+
+        Parameters
+        ----------
+        rdkmol : rdkit.Chem.RWMol
+            The RDKMol to use.
+        """
+        rdkconf = rdkmol.GetConformers()[0]
+        self.atoms.coordinates = rdkconf.GetPositions()
+
+    def coordinates_to_RDKMol(self, rdkmol):
+        """Update the coordinates of an RDKMol from this configuration.
+
+        Parameters
+        ----------
+        rdkmol : rdkit.Chem.RWMol
+            The RDKMol to use.
+        """
+        rdkconf = rdkmol.GetConformers()[0]
+        rdkconf.SetPositions(self.atoms.coordinates)
+
     def to_RDKMol(self, properties=None):
         """Return an RDKMol object for the configuration, template, or subset."""
         index = {}

--- a/molsystem/system.py
+++ b/molsystem/system.py
@@ -116,7 +116,7 @@ class _System(CIFMixin, MutableMapping):
         table : Table or Atom, Template, Templateatoms, ...
         """
         if key not in self._items:
-            self._items[key] = _Table(self, key)
+            self._items[key] = _Table(self.system_db, key)
         return self._items[key]
 
     def __setitem__(self, key, value):
@@ -190,7 +190,7 @@ class _System(CIFMixin, MutableMapping):
         # Check the tables in both systems
         result = True
         for table in in_common:
-            if _Table(self, table) != _Table(other, table):
+            if _Table(self.system_db, table) != _Table(other.system_db, table):
                 result = False
                 break
 
@@ -504,25 +504,25 @@ class _System(CIFMixin, MutableMapping):
 
         # Need the contents of the tables. See if they are in the same
         # database or if we need to attach the other database temporarily.
-        name = self.nickname
-        other_name = other.nickname
-        detach = False
-        if name != other_name and not self.is_attached(other_name):
-            # Attach the other system in order to do comparisons.
-            self.attach(other)
-            detach = True
+        # name = self.nickname
+        # other_name = other.nickname
+        # detach = False
+        # if name != other_name and not self.is_attached(other_name):
+        #     # Attach the other system in order to do comparisons.
+        #     self.attach(other)
+        #     detach = True
 
         # Check the tables in both systems
         for table in in_common:
-            table1 = _Table(self, table)
-            table2 = _Table(other, table)
+            table1 = _Table(self.system_db, table)
+            table2 = _Table(other.system_db, table)
             tmp = table1.diff(table2)
-            if len(tmp) > 0:
+            if tmp is not None:
                 result[f"table '{table}' diffs"] = tmp
 
         # Detach the other database if needed
-        if detach:
-            self.detach(other)
+        # if detach:
+        #     self.detach(other)
 
         return result
 

--- a/tests/test_openbabel.py
+++ b/tests/test_openbabel.py
@@ -367,6 +367,76 @@ known_input_formats["Linux"] = (
 )
 known_input_formats["Windows"] = known_input_formats["Darwin"]
 
+copper_sdf = """SEAMM=default/FCC Copper
+ OpenBabel03252515063D
+
+  4  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 Cu  0  0  0  0  0 15  0  0  0  0  0  0
+    1.8075    1.8075    0.0000 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+    1.8075    0.0000    1.8075 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+    0.0000    1.8075    1.8075 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+M  RAD  1   1   1
+M  END
+>  <SEAMM|net charge|int|>
+0
+
+>  <SEAMM|spin multiplicity|int|>
+1
+
+>  <SEAMM|XYZ|json|>
+[
+    [0, 0, 0],
+    [1.807455, 1.807455, 0],
+    [1.807455, 0, 1.807455],
+    [0, 1.807455, 1.807455]
+]
+
+>  <SEAMM|cell|json|>
+[3.61491, 3.61491, 3.61491, 90, 90, 90]
+
+>  <SEAMM|system name|str|>
+default
+
+>  <SEAMM|configuration name|str|>
+FCC Copper
+
+$$$$"""
+
+copper_sdf_2 = """SEAMM=default/FCC Copper
+ OpenBabel03252519453D
+
+  4  0  0  0  0  0  0  0  0  0999 V2000
+    0.0000    0.0000    0.0000 Cu  0  0  0  0  0 15  0  0  0  0  0  0
+    1.8075    1.8075    0.0000 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+    1.8075    3.6149    1.8075 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+    3.6149    1.8075    1.8075 Cu  0  0  0  0  0  0  0  0  0  0  0  0
+M  RAD  1   1   1
+M  END
+>  <SEAMM|net charge|int|>
+0
+
+>  <SEAMM|spin multiplicity|int|>
+1
+
+>  <SEAMM|XYZ|json|>
+[
+    [0, 0, 0],
+    [1.807455, 1.807455, 0],
+    [1.807455, 0, 1.807455],
+    [0, 1.807455, 1.807455]
+]
+
+>  <SEAMM|cell|json|>
+[3.61491, 3.61491, 3.61491, 90, 90, 90]
+
+>  <SEAMM|system name|str|>
+default
+
+>  <SEAMM|configuration name|str|>
+FCC Copper
+
+$$$$"""
+
 
 def test_version():
     """Test the version number of Open Babel."""
@@ -448,6 +518,7 @@ def test_substructure_ordering(disordered):
 
 
 def test_all_residue_search(configuration):
+    return
     """Testing locating residues in a peptide."""
     residues = {
         "ARG_LL": [(9, 10, 11, 12, 13, 14, 15, 17, 16, 18, 19)],
@@ -582,3 +653,47 @@ def test_input_formats():
         print(system)
         pprint.pprint(formats)
     assert formats == known_input_formats[system]
+
+
+def test_copper_to_sdf(copper):
+    """Write a manually created configuration to molfile"""
+    saved = copper.to_sdf_text()
+    tmp = saved.splitlines()
+    del tmp[1]
+    text = "\n".join(tmp)
+
+    correct = copper_sdf.splitlines()
+    del correct[1]
+    correct = "\n".join(correct)
+
+    if text != correct:
+        print(saved)
+    assert text == correct
+
+
+def test_copper_from_sdf(copper):
+    """Read an sdf file for periodic system"""
+
+    system = copper.system.system_db.create_system()
+    configuration = system.create_configuration()
+    sysname, confname = configuration.from_sdf_text(copper_sdf, properties="")
+    configuration.name = confname
+    configuration.system.name = sysname
+
+    result = configuration.system.diff(copper.system)
+    if result != {}:
+        pprint.pprint(result)
+    assert result == {}
+
+    saved = configuration.to_sdf_text()
+    tmp = saved.splitlines()
+    del tmp[1]
+    text = "\n".join(tmp)
+
+    correct = copper_sdf_2.splitlines()
+    del correct[1]
+    correct = "\n".join(correct)
+
+    if text != correct:
+        print(saved)
+    assert text == correct

--- a/tests/test_openbabel.py
+++ b/tests/test_openbabel.py
@@ -518,7 +518,6 @@ def test_substructure_ordering(disordered):
 
 
 def test_all_residue_search(configuration):
-    return
     """Testing locating residues in a peptide."""
     residues = {
         "ARG_LL": [(9, 10, 11, 12, 13, 14, 15, 17, 16, 18, 19)],


### PR DESCRIPTION
* Enhanced the OpenBabel molecule interface to handle periodic systems better, which in turn supports using SDF files for periodic systems using SEAMM-specific customization. The coordinates are always stored as Cartesians, and the cell information is added as a property, and used when reading periodic systems written by SEAMM.
* Added code to the RDKit interface to allow setting/getting just the coordinates to/from a RDKit Molecule object. This is in analogy to the implementation in OpenBabel.
* Added code to truncate near zero coordinates and cell parameters (< 1.0e-6) to make coordinates and the cell parameters easier to read.