### PR TITLE
Bugfix: accidentally deleting atoms in configurations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,12 @@
 =======
 History
 =======
+2025.5.7 -- Bugfix: accidentally deleting atoms in configurations
+    * Some parts of the code recreated the atoms in a configuration from a RDKMol
+      object, when all that was needed was updating the coordinates. Due to a bug in
+      handling the atoms shared between configurations this led to all the atoms being
+      deleted from some configurations. This has been fixed.
+      
 2025.4.1 -- Enhancement to OpenBabel/SDF to handle periodic systems
     * Enhanced the OpenBabel molecule interface to handle periodic systems better, which
       in turn supports using SDF files for periodic systems using SEAMM-specific

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,12 @@
 History
 =======
 2025.5.7 -- Bugfix: accidentally deleting atoms in configurations
-    * Some parts of the code recreated the atoms in a configuration from a RDKMol
-      object, when all that was needed was updating the coordinates. Due to a bug in
-      handling the atoms shared between configurations this led to all the atoms being
-      deleted from some configurations. This has been fixed.
+    * Fixed an issue where atoms in a configuration were being deleted due to improper
+      handling of shared atoms when updating coordinates from an RDKMol object. The code
+      now updates the coordinates directly without recreating the atoms, ensuring that
+      configurations retain their atoms as expected. This change prevents unintended
+      data loss and ensures consistency when working with shared atoms across multiple
+     configurations.
       
 2025.4.1 -- Enhancement to OpenBabel/SDF to handle periodic systems
     * Enhanced the OpenBabel molecule interface to handle periodic systems better, which

--- a/molsystem/align.py
+++ b/molsystem/align.py
@@ -147,7 +147,7 @@ def RMSD(
         )
         if align:
             if isinstance(structure, _Configuration):
-                structure.from_RDKMol(_structure)
+                structure.coordinates_from_RDKMol(_structure)
             else:
                 structure.GetConformer(0).SetPositions(
                     _structure.GetConformer(0).GetPositions()
@@ -161,7 +161,7 @@ def RMSD(
         )
         if align:
             if isinstance(structure, _Configuration):
-                structure.from_OBMol(_structure)
+                structure.coordinates_from_OBMol(_structure)
             else:
                 for at1, at2 in zip(
                     ob.OBMolAtomIter(structure), ob.OBMolAtomIter(_structure)

--- a/molsystem/atoms.py
+++ b/molsystem/atoms.py
@@ -40,8 +40,6 @@ class _Atoms(_Table):
         self._system_db = self._configuration.system_db
         self._system = None
 
-        self._atomset = self._configuration.atomset
-
         self._atom_table = _Table(self.system_db, "atom")
         self._coordinates_table = _Table(self.system_db, "coordinates")
         self._velocities_table = _Table(self.system_db, "velocities")
@@ -176,7 +174,7 @@ class _Atoms(_Table):
     @property
     def atomset(self):
         """The atomset for these atoms."""
-        return self._atomset
+        return self._configuration.atomset
 
     @property
     def atom_generators(self):

--- a/molsystem/smiles.py
+++ b/molsystem/smiles.py
@@ -152,8 +152,6 @@ class SMILESMixin:
         str
             The SMILES string, or (SMILES, name) if the rname is requested
         """
-        logger.info("to_smiles")
-
         if flavor == "rdkit":
             mol = self.to_RDKMol()
             if isomeric:
@@ -189,8 +187,6 @@ class SMILESMixin:
             smiles = oechem.OECreateSmiString(mol)
         else:
             raise ValueError(f"flavor of SMILES '{flavor}' not supported")
-
-        logger.info(f"smiles = '{smiles}'")
 
         return smiles.strip()
 
@@ -276,7 +272,7 @@ class SMILESMixin:
             rdkMol = self.to_RDKMol()
             rdkConf = rdkMol.GetConformers()[0]
             Chem.rdMolTransforms.CanonicalizeConformer(rdkConf, ignoreHs=False)
-            self.from_RDKMol(rdkMol)
+            self.coordinates_from_RDKMol(rdkMol)
 
         if name is not None:
             self.name = name


### PR DESCRIPTION
* Fixed an issue where atoms in a configuration were being deleted due to improper handling of shared atoms when updating coordinates from an RDKMol object. The code now updates the coordinates directly without recreating the atoms, ensuring that configurations retain their atoms as expected. This change prevents unintended data loss and ensures consistency when working with shared atoms across multiple configurations.