### PR TITLE
Bugfix: Ensure that the name of systems and configurations is a string.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,11 @@
 =======
 History
 =======
+2025.8.5 -- Bugfix: Ensure that the name of systems and configurations is a string.
+    * The name of a system or configuration could be None, not a string, which then
+      caused problems in other parts of the code. Now, if there is no name, it is
+      returned as an empty string.
+
 2025.5.19 -- Enhancements to SMILES and added PubChem standardization
     * Added special handling for the valency of boron ions to handle compounds like BH4-,
       which have a negative charge because boron only has 3 valence electrons.

--- a/molsystem/configuration.py
+++ b/molsystem/configuration.py
@@ -460,6 +460,8 @@ class _Configuration(
                 "SELECT name FROM configuration WHERE id = ?", (self.id,)
             )
             self._name = self.cursor.fetchone()[0]
+            if self._name is None:
+                self._name = ""
         return self._name
 
     @name.setter

--- a/molsystem/system.py
+++ b/molsystem/system.py
@@ -282,6 +282,8 @@ class _System(CIFMixin, MutableMapping):
         if result is None:
             return None
         else:
+            if result[0] is None:
+                return ""
             return result[0]
 
     @name.setter


### PR DESCRIPTION
* The name of a system or configuration could be None, not a string, which then caused problems in other parts of the code. Now, if there is no name, it is returned as an empty string.