### PR TITLE
Fixed a further deprecation in RDKit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,3 +105,12 @@ install: uninstall ## install the package to the active Python's site-packages
 
 uninstall: clean ## uninstall the package
 	pip uninstall --yes $(MODULE)
+
+.PHONY: update
+update: ## post-release: sync main and dev, reinstall, run checks, push dev
+	git checkout main
+	git pull
+	git checkout dev
+	git merge --ff-only main
+	$(MAKE) lint install test
+	git push

--- a/molsystem/rdkit_.py
+++ b/molsystem/rdkit_.py
@@ -22,16 +22,28 @@ logger = logging.getLogger(__name__)
 
 
 def _explicit_valence(atom):
-    """The atom's explicit valence, across RDKit's API rename.
+    """The atom's explicit valence, across RDKit's API changes.
 
-    Newer RDKit deprecates ``GetExplicitValence()`` in favor of
-    ``GetValence(Chem.ValenceType.EXPLICIT)``; use the new API when present and
-    fall back to the old method for older RDKit.
+    RDKit's valence API has moved in two steps, and different installed
+    versions are at different points:
+
+    1. oldest -- ``GetExplicitValence()`` (no ``ValenceType``);
+    2. newer  -- ``GetValence(Chem.ValenceType.EXPLICIT)`` positional;
+    3. newest -- the positional form is deprecated too; it wants the keyword
+       ``GetValence(which=Chem.ValenceType.EXPLICIT)``.
+
+    Prefer the keyword form (warning-free on current RDKit), fall back to the
+    positional form, then to the old method -- so this stays quiet on every
+    version.
     """
     valence_type = getattr(Chem, "ValenceType", None)
-    if valence_type is not None:
+    if valence_type is None:
+        return atom.GetExplicitValence()
+    try:
+        return atom.GetValence(which=valence_type.EXPLICIT)
+    except TypeError:
+        # An RDKit binding with ValenceType but without the `which` keyword.
         return atom.GetValence(valence_type.EXPLICIT)
-    return atom.GetExplicitValence()
 
 
 # Valence


### PR DESCRIPTION
RDKit changed again to require a keyword argument: GetValence(which=valence_type.EXPLICIT) so the helper routine now handles all three variants quietly.