### PR TITLE
Added geometric transforms and combining of configurations

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 =======
 History
 =======
+2026.6.29 -- Added geometric transforms and combining of configurations
+    * Added rigid-body transforms for a (molecular) configuration: the center of mass
+      or geometric centroid, and in-place translate, rotate (about the center of mass,
+      centroid, origin, or an explicit point), and a general affine transform. Helpers
+      are provided to build rotation matrices from an axis and angle, from a quaternion,
+      or as a uniformly random orientation.
+    * Added a method to combine two or more configurations into a single new
+      configuration -- for example assembling a dimer or larger cluster from separate
+      molecules -- optionally rotating and displacing each molecule into place as it is
+      added.
+    * These operations are supported for molecular (non-periodic) systems.
+
 2026.2.25 -- Bugfix: Fixed issues getting atoms and bonds for subsets.
     * Also replaced deprecated pkg_index module with the importlib module.
       

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,10 +7,11 @@ History
       centroid, origin, or an explicit point), and a general affine transform. Helpers
       are provided to build rotation matrices from an axis and angle, from a quaternion,
       or as a uniformly random orientation.
-    * Added a method to combine two or more configurations into a single new
-      configuration -- for example assembling a dimer or larger cluster from separate
-      molecules -- optionally rotating and displacing each molecule into place as it is
-      added.
+    * Added a method to combine two or more configurations into a new system -- for
+      example assembling a dimer or larger cluster from separate molecules -- optionally
+      rotating and displacing each molecule into place as it is added. Combining always
+      makes a new system, so further configurations added to it are conformers with the
+      same atoms and bonds.
     * These operations are supported for molecular (non-periodic) systems.
 
 2026.2.25 -- Bugfix: Fixed issues getting atoms and bonds for subsets.

--- a/molsystem/__init__.py
+++ b/molsystem/__init__.py
@@ -27,6 +27,11 @@ from .cell import Cell  # noqa: F401
 from .properties import standard_properties, add_properties_from_file  # noqa: F401
 from .openbabel import openbabel_version, openbabel_citations  # noqa: F401
 from .align import RMSD  # noqa: F401
+from .transform import (  # noqa: F401
+    random_rotation_matrix,
+    rotation_matrix_from_axis_angle,
+    rotation_matrix_from_quaternion,
+)
 from .pubchem import PC_standardize  # noqa: F401
 
 try:

--- a/molsystem/configuration.py
+++ b/molsystem/configuration.py
@@ -30,6 +30,7 @@ from .pdb import PDBMixin
 from .qcschema import QCSchemaMixin
 from .smiles import SMILESMixin
 from .topology import TopologyMixin
+from .transform import TransformMixin
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +62,7 @@ class _Configuration(
     RDKitMixin,
     QCSchemaMixin,
     AlignMixin,
+    TransformMixin,
     object,
 ):
     """A configuration (conformer) of a system."""

--- a/molsystem/system.py
+++ b/molsystem/system.py
@@ -6,8 +6,6 @@ from collections.abc import MutableMapping
 import logging
 import pprint  # noqa: F401
 
-import numpy as np
-
 from .cif import CIFMixin
 from .configuration import _Configuration
 from .system_properties import _SystemProperties
@@ -368,116 +366,6 @@ class _System(CIFMixin, MutableMapping):
         new.spin_multiplicity = previous.spin_multiplicity
         new.n_active_electrons = previous.n_active_electrons
         new.n_active_orbitals = previous.n_active_orbitals
-
-        return new
-
-    def create_combined_configuration(
-        self,
-        configurations,
-        transforms=None,
-        name=None,
-        make_current=False,
-    ):
-        """Create a new configuration by combining two or more configurations.
-
-        The atoms and bonds of each source configuration are concatenated into
-        a new configuration in this system, producing a single molecular system
-        that contains all the input molecules -- for example a dimer assembled
-        from two monomers, or an n-mer cluster. Each source's coordinates may be
-        transformed as it is added, which is how a partner molecule is rotated
-        and displaced into position. The source configurations are not modified.
-
-        Only non-periodic (molecular) configurations are supported; combining
-        with a periodic system (e.g. a molecule onto a surface) is not handled.
-
-        Parameters
-        ----------
-        configurations : [_Configuration]
-            The source configurations to combine, in order. They must belong to
-            the same system database as this system.
-        transforms : [array-like or None] = None
-            An optional list, parallel to ``configurations``, of 3x3 rotation or
-            4x4 affine matrices (RDKit ``TransformMol`` convention,
-            ``p' = R·p + t``) applied to each source's coordinates as it is
-            added. Use None for a source that should be placed unchanged. The
-            helpers in ``molsystem.transform`` build suitable matrices.
-        name : str = None
-            A textual name for the new configuration.
-        make_current : bool = False
-            Whether to make the new configuration the current one.
-
-        Returns
-        -------
-        _Configuration
-            The new, combined configuration.
-        """
-        configurations = list(configurations)
-        if len(configurations) == 0:
-            raise ValueError("Need at least one configuration to combine.")
-
-        if transforms is None:
-            transforms = [None] * len(configurations)
-        elif len(transforms) != len(configurations):
-            raise ValueError(
-                "'transforms' must be the same length as 'configurations'."
-            )
-
-        for cfg in configurations:
-            if cfg.periodicity != 0:
-                raise ValueError(
-                    "Combining configurations is only supported for non-periodic "
-                    "(molecular) systems."
-                )
-
-        new = self.create_configuration(
-            name=name, periodicity=0, make_current=make_current
-        )
-
-        total_charge = 0
-        for cfg, matrix in zip(configurations, transforms):
-            atnos = cfg.atoms.atomic_numbers
-            xyz = np.array(
-                cfg.atoms.get_coordinates(fractionals=False, as_array=True),
-                dtype=float,
-            )
-
-            if matrix is not None:
-                M = np.asarray(matrix, dtype=float)
-                if M.shape == (3, 3):
-                    R = M
-                    t = np.zeros(3)
-                elif M.shape == (4, 4):
-                    R = M[:3, :3]
-                    t = M[:3, 3]
-                else:
-                    raise ValueError(
-                        "Each transform must be a 3x3 or 4x4 matrix, not shape "
-                        f"{M.shape}."
-                    )
-                xyz = xyz @ R.T + t
-
-            new_ids = new.atoms.append(
-                atno=list(atnos),
-                x=xyz[:, 0].tolist(),
-                y=xyz[:, 1].tolist(),
-                z=xyz[:, 2].tolist(),
-            )
-
-            # Remap and copy this source's bonds onto the new atom ids.
-            i_ids = cfg.bonds.get_column_data("i")
-            if len(i_ids) > 0:
-                j_ids = cfg.bonds.get_column_data("j")
-                bondorders = cfg.bonds.get_column_data("bondorder")
-                id_map = dict(zip(cfg.atoms.ids, new_ids))
-                new.bonds.append(
-                    i=[id_map[a] for a in i_ids],
-                    j=[id_map[a] for a in j_ids],
-                    bondorder=bondorders,
-                )
-
-            total_charge += cfg.charge
-
-        new.charge = total_charge
 
         return new
 

--- a/molsystem/system.py
+++ b/molsystem/system.py
@@ -6,6 +6,8 @@ from collections.abc import MutableMapping
 import logging
 import pprint  # noqa: F401
 
+import numpy as np
+
 from .cif import CIFMixin
 from .configuration import _Configuration
 from .system_properties import _SystemProperties
@@ -366,6 +368,116 @@ class _System(CIFMixin, MutableMapping):
         new.spin_multiplicity = previous.spin_multiplicity
         new.n_active_electrons = previous.n_active_electrons
         new.n_active_orbitals = previous.n_active_orbitals
+
+        return new
+
+    def create_combined_configuration(
+        self,
+        configurations,
+        transforms=None,
+        name=None,
+        make_current=False,
+    ):
+        """Create a new configuration by combining two or more configurations.
+
+        The atoms and bonds of each source configuration are concatenated into
+        a new configuration in this system, producing a single molecular system
+        that contains all the input molecules -- for example a dimer assembled
+        from two monomers, or an n-mer cluster. Each source's coordinates may be
+        transformed as it is added, which is how a partner molecule is rotated
+        and displaced into position. The source configurations are not modified.
+
+        Only non-periodic (molecular) configurations are supported; combining
+        with a periodic system (e.g. a molecule onto a surface) is not handled.
+
+        Parameters
+        ----------
+        configurations : [_Configuration]
+            The source configurations to combine, in order. They must belong to
+            the same system database as this system.
+        transforms : [array-like or None] = None
+            An optional list, parallel to ``configurations``, of 3x3 rotation or
+            4x4 affine matrices (RDKit ``TransformMol`` convention,
+            ``p' = R·p + t``) applied to each source's coordinates as it is
+            added. Use None for a source that should be placed unchanged. The
+            helpers in ``molsystem.transform`` build suitable matrices.
+        name : str = None
+            A textual name for the new configuration.
+        make_current : bool = False
+            Whether to make the new configuration the current one.
+
+        Returns
+        -------
+        _Configuration
+            The new, combined configuration.
+        """
+        configurations = list(configurations)
+        if len(configurations) == 0:
+            raise ValueError("Need at least one configuration to combine.")
+
+        if transforms is None:
+            transforms = [None] * len(configurations)
+        elif len(transforms) != len(configurations):
+            raise ValueError(
+                "'transforms' must be the same length as 'configurations'."
+            )
+
+        for cfg in configurations:
+            if cfg.periodicity != 0:
+                raise ValueError(
+                    "Combining configurations is only supported for non-periodic "
+                    "(molecular) systems."
+                )
+
+        new = self.create_configuration(
+            name=name, periodicity=0, make_current=make_current
+        )
+
+        total_charge = 0
+        for cfg, matrix in zip(configurations, transforms):
+            atnos = cfg.atoms.atomic_numbers
+            xyz = np.array(
+                cfg.atoms.get_coordinates(fractionals=False, as_array=True),
+                dtype=float,
+            )
+
+            if matrix is not None:
+                M = np.asarray(matrix, dtype=float)
+                if M.shape == (3, 3):
+                    R = M
+                    t = np.zeros(3)
+                elif M.shape == (4, 4):
+                    R = M[:3, :3]
+                    t = M[:3, 3]
+                else:
+                    raise ValueError(
+                        "Each transform must be a 3x3 or 4x4 matrix, not shape "
+                        f"{M.shape}."
+                    )
+                xyz = xyz @ R.T + t
+
+            new_ids = new.atoms.append(
+                atno=list(atnos),
+                x=xyz[:, 0].tolist(),
+                y=xyz[:, 1].tolist(),
+                z=xyz[:, 2].tolist(),
+            )
+
+            # Remap and copy this source's bonds onto the new atom ids.
+            i_ids = cfg.bonds.get_column_data("i")
+            if len(i_ids) > 0:
+                j_ids = cfg.bonds.get_column_data("j")
+                bondorders = cfg.bonds.get_column_data("bondorder")
+                id_map = dict(zip(cfg.atoms.ids, new_ids))
+                new.bonds.append(
+                    i=[id_map[a] for a in i_ids],
+                    j=[id_map[a] for a in j_ids],
+                    bondorder=bondorders,
+                )
+
+            total_charge += cfg.charge
+
+        new.charge = total_charge
 
         return new
 

--- a/molsystem/system_db.py
+++ b/molsystem/system_db.py
@@ -6,6 +6,8 @@ import collections.abc
 import logging
 import sqlite3
 
+import numpy as np
+
 import molsystem
 from .cif import CIFMixin
 from .configuration import _Configuration
@@ -525,6 +527,123 @@ class SystemDB(CIFMixin, collections.abc.MutableMapping):
             self._current_system_id = _id
 
         return _System(self, _id)
+
+    def create_combined_system(
+        self,
+        configurations,
+        transforms=None,
+        name="",
+        make_current=True,
+    ):
+        """Create a new system whose configuration combines two or more molecules.
+
+        A fresh, empty system is created and a single configuration is built in
+        it by concatenating the atoms and bonds of the given source
+        configurations -- for example assembling a dimer or larger cluster from
+        separate molecules. Each source's coordinates may be transformed as it
+        is added, which is how a partner molecule is rotated and displaced into
+        position. The source configurations are not modified.
+
+        Combining always creates a *new* system rather than adding to an
+        existing one. That way every configuration subsequently added to the
+        system is a true conformer -- the same atoms and bonds, differing only
+        in coordinates (e.g. via :meth:`_System.copy_configuration`) -- so the
+        system stays homogeneous and different molecules are never accidentally
+        mixed into one system.
+
+        Only non-periodic (molecular) configurations are supported; combining
+        onto a periodic system (e.g. a molecule on a surface) is not handled.
+
+        Parameters
+        ----------
+        configurations : [_Configuration]
+            The source configurations to combine, in order. They must belong to
+            this system database.
+        transforms : [array-like or None] = None
+            An optional list, parallel to ``configurations``, of 3x3 rotation or
+            4x4 affine matrices (RDKit ``TransformMol`` convention,
+            ``p' = R·p + t``) applied to each source's coordinates as it is
+            added. Use None for a source that should be placed unchanged. The
+            helpers in ``molsystem.transform`` build suitable matrices.
+        name : str = ""
+            A name for the new system and its configuration.
+        make_current : bool = True
+            Whether to make the new system the current one.
+
+        Returns
+        -------
+        _System
+            The new system. Its (current) configuration is the combined
+            structure.
+        """
+        configurations = list(configurations)
+        if len(configurations) == 0:
+            raise ValueError("Need at least one configuration to combine.")
+
+        if transforms is None:
+            transforms = [None] * len(configurations)
+        elif len(transforms) != len(configurations):
+            raise ValueError(
+                "'transforms' must be the same length as 'configurations'."
+            )
+
+        for cfg in configurations:
+            if cfg.periodicity != 0:
+                raise ValueError(
+                    "Combining configurations is only supported for non-periodic "
+                    "(molecular) systems."
+                )
+
+        system = self.create_system(name=name, make_current=make_current)
+        new = system.create_configuration(name=name, periodicity=0, make_current=True)
+
+        total_charge = 0
+        for cfg, matrix in zip(configurations, transforms):
+            atnos = cfg.atoms.atomic_numbers
+            xyz = np.array(
+                cfg.atoms.get_coordinates(fractionals=False, as_array=True),
+                dtype=float,
+            )
+
+            if matrix is not None:
+                M = np.asarray(matrix, dtype=float)
+                if M.shape == (3, 3):
+                    R = M
+                    t = np.zeros(3)
+                elif M.shape == (4, 4):
+                    R = M[:3, :3]
+                    t = M[:3, 3]
+                else:
+                    raise ValueError(
+                        "Each transform must be a 3x3 or 4x4 matrix, not shape "
+                        f"{M.shape}."
+                    )
+                xyz = xyz @ R.T + t
+
+            new_ids = new.atoms.append(
+                atno=list(atnos),
+                x=xyz[:, 0].tolist(),
+                y=xyz[:, 1].tolist(),
+                z=xyz[:, 2].tolist(),
+            )
+
+            # Remap and copy this source's bonds onto the new atom ids.
+            i_ids = cfg.bonds.get_column_data("i")
+            if len(i_ids) > 0:
+                j_ids = cfg.bonds.get_column_data("j")
+                bondorders = cfg.bonds.get_column_data("bondorder")
+                id_map = dict(zip(cfg.atoms.ids, new_ids))
+                new.bonds.append(
+                    i=[id_map[a] for a in i_ids],
+                    j=[id_map[a] for a in j_ids],
+                    bondorder=bondorders,
+                )
+
+            total_charge += cfg.charge
+
+        new.charge = total_charge
+
+        return system
 
     def create_table(self, name, cls=_Table, other=None):
         """Create a new table with the given name.

--- a/molsystem/transform.py
+++ b/molsystem/transform.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+
+"""Rigid-body geometric transforms (translation, rotation) of a configuration.
+
+The transforms operate on Cartesian coordinates in Å, modify the configuration
+in place, and return ``self`` so that calls can be chained, e.g.::
+
+    configuration.rotate(R, about="com").translate([0.0, 0.0, 5.0])
+
+They are supported only for molecular (non-periodic) systems; calling them on a
+periodic configuration raises a ``ValueError``. (Rigid-body moves of a periodic
+system would also have to transform the unit cell to be meaningful, which is a
+separate problem.)
+
+The module also provides helpers for constructing rotation matrices
+(:func:`rotation_matrix_from_axis_angle`, :func:`rotation_matrix_from_quaternion`,
+:func:`random_rotation_matrix`).
+"""
+
+import math
+
+import numpy as np
+
+
+def rotation_matrix_from_axis_angle(axis, angle, degrees=True):
+    """Build a 3x3 rotation matrix from an axis and angle (Rodrigues' formula).
+
+    Parameters
+    ----------
+    axis : [float]*3
+        The axis to rotate about. Need not be normalized.
+    angle : float
+        The angle to rotate through.
+    degrees : bool = True
+        Whether ``angle`` is in degrees (the default) or radians.
+
+    Returns
+    -------
+    numpy.ndarray
+        A 3x3 rotation matrix.
+    """
+    axis = np.asarray(axis, dtype=float)
+    norm = np.linalg.norm(axis)
+    if norm == 0.0:
+        raise ValueError("The rotation axis must be a non-zero vector.")
+    x, y, z = axis / norm
+
+    if degrees:
+        angle = math.radians(angle)
+    c = math.cos(angle)
+    s = math.sin(angle)
+    C = 1.0 - c
+
+    return np.array(
+        [
+            [c + x * x * C, x * y * C - z * s, x * z * C + y * s],
+            [y * x * C + z * s, c + y * y * C, y * z * C - x * s],
+            [z * x * C - y * s, z * y * C + x * s, c + z * z * C],
+        ]
+    )
+
+
+def rotation_matrix_from_quaternion(quaternion):
+    """Build a 3x3 rotation matrix from a quaternion (w, x, y, z).
+
+    Parameters
+    ----------
+    quaternion : [float]*4
+        The quaternion as (w, x, y, z). Need not be normalized.
+
+    Returns
+    -------
+    numpy.ndarray
+        A 3x3 rotation matrix.
+    """
+    q = np.asarray(quaternion, dtype=float)
+    norm = np.linalg.norm(q)
+    if norm == 0.0:
+        raise ValueError("The quaternion must be a non-zero vector.")
+    w, x, y, z = q / norm
+
+    return np.array(
+        [
+            [
+                1.0 - 2.0 * (y * y + z * z),
+                2.0 * (x * y - z * w),
+                2.0 * (x * z + y * w),
+            ],
+            [
+                2.0 * (x * y + z * w),
+                1.0 - 2.0 * (x * x + z * z),
+                2.0 * (y * z - x * w),
+            ],
+            [
+                2.0 * (x * z - y * w),
+                2.0 * (y * z + x * w),
+                1.0 - 2.0 * (x * x + y * y),
+            ],
+        ]
+    )
+
+
+def random_rotation_matrix(rng=None):
+    """A rotation matrix sampled uniformly from SO(3).
+
+    Uses Shoemake's algorithm to draw a uniformly distributed unit quaternion.
+
+    Parameters
+    ----------
+    rng : numpy.random.Generator = None
+        The random-number generator to use. If None, a fresh default generator
+        is created. Pass a seeded generator for reproducible orientations.
+
+    Returns
+    -------
+    numpy.ndarray
+        A 3x3 rotation matrix.
+    """
+    if rng is None:
+        rng = np.random.default_rng()
+    u1, u2, u3 = rng.random(3)
+    r1 = math.sqrt(1.0 - u1)
+    r2 = math.sqrt(u1)
+    two_pi = 2.0 * math.pi
+    quaternion = (
+        r2 * math.cos(two_pi * u3),  # w
+        r1 * math.sin(two_pi * u2),  # x
+        r1 * math.cos(two_pi * u2),  # y
+        r2 * math.sin(two_pi * u3),  # z
+    )
+    return rotation_matrix_from_quaternion(quaternion)
+
+
+class TransformMixin:
+    """A mixin giving a configuration rigid-body transform operations."""
+
+    def center_of_mass(self, atoms=None, mass_weighted=True):
+        """The center of mass (or geometric centroid) of the configuration.
+
+        Parameters
+        ----------
+        atoms : [int] = None
+            Optional 0-based positional indices selecting a subset of atoms
+            (e.g. one fragment of a complex). By default all atoms are used.
+        mass_weighted : bool = True
+            If True (the default) return the mass-weighted center of mass; if
+            False return the unweighted geometric centroid.
+
+        Returns
+        -------
+        numpy.ndarray
+            The center of mass as a length-3 array, in Å.
+        """
+        xyz = self.atoms.get_coordinates(fractionals=False, as_array=True)
+        xyz = np.asarray(xyz, dtype=float)
+        if atoms is not None:
+            xyz = xyz[list(atoms)]
+
+        if mass_weighted:
+            masses = np.asarray(self.atoms.atomic_masses, dtype=float)
+            if atoms is not None:
+                masses = masses[list(atoms)]
+            total = masses.sum()
+            if total == 0.0:
+                raise ValueError("The total mass is zero; cannot form a COM.")
+            return (masses[:, np.newaxis] * xyz).sum(axis=0) / total
+        else:
+            return xyz.mean(axis=0)
+
+    def centroid(self, atoms=None):
+        """The (unweighted) geometric centroid of the configuration.
+
+        A convenience wrapper for ``center_of_mass(mass_weighted=False)``.
+        """
+        return self.center_of_mass(atoms=atoms, mass_weighted=False)
+
+    def translate(self, displacement, atoms=None):
+        """Translate the configuration (or a subset of atoms) in place.
+
+        Parameters
+        ----------
+        displacement : [float]*3
+            The displacement vector, in Å.
+        atoms : [int] = None
+            Optional 0-based positional indices selecting a subset of atoms.
+            By default all atoms are moved.
+
+        Returns
+        -------
+        self
+        """
+        self._require_nonperiodic("translate")
+        d = np.asarray(displacement, dtype=float).reshape(3)
+        return self._apply_to_coordinates(lambda c: c + d, atoms=atoms)
+
+    def rotate(self, rotation, about="com", atoms=None):
+        """Rotate the configuration (or a subset of atoms) in place.
+
+        Parameters
+        ----------
+        rotation : array-like
+            A 3x3 rotation matrix, or a 4x4 matrix whose upper-left 3x3 block is
+            used. The helpers :func:`rotation_matrix_from_axis_angle`,
+            :func:`rotation_matrix_from_quaternion`, and
+            :func:`random_rotation_matrix` build suitable matrices.
+        about : str or [float]*3 = "com"
+            The point to rotate about: "com" (center of mass), "centroid"
+            (geometric center), "origin", or an explicit length-3 point in Å.
+            When a subset of atoms is given, "com"/"centroid" refer to that
+            subset.
+        atoms : [int] = None
+            Optional 0-based positional indices selecting a subset of atoms.
+            By default the whole configuration is rotated.
+
+        Returns
+        -------
+        self
+        """
+        self._require_nonperiodic("rotate")
+        R = np.asarray(rotation, dtype=float)
+        if R.shape == (4, 4):
+            R = R[:3, :3]
+        if R.shape != (3, 3):
+            raise ValueError(
+                f"The rotation must be a 3x3 or 4x4 matrix, not shape {R.shape}."
+            )
+
+        center = self._resolve_point(about, atoms=atoms)
+        return self._apply_to_coordinates(
+            lambda c: (c - center) @ R.T + center, atoms=atoms
+        )
+
+    def transform(self, matrix, atoms=None):
+        """Apply a general affine transform in place (RDKit ``TransformMol`` form).
+
+        The transform of a point ``p`` is ``R @ p + t``, where ``R`` and ``t``
+        are taken from a 4x4 homogeneous matrix (or ``R`` from a 3x3 matrix with
+        ``t`` = 0). This matches the convention used by RDKit's
+        ``AllChem.TransformMol``, so a matrix obtained from RDKit alignment can
+        be applied directly.
+
+        Parameters
+        ----------
+        matrix : array-like
+            A 3x3 (rotation only) or 4x4 (rotation + translation) matrix.
+        atoms : [int] = None
+            Optional 0-based positional indices selecting a subset of atoms.
+
+        Returns
+        -------
+        self
+        """
+        self._require_nonperiodic("transform")
+        M = np.asarray(matrix, dtype=float)
+        if M.shape == (3, 3):
+            R = M
+            t = np.zeros(3)
+        elif M.shape == (4, 4):
+            R = M[:3, :3]
+            t = M[:3, 3]
+        else:
+            raise ValueError(
+                f"The transform must be a 3x3 or 4x4 matrix, not shape {M.shape}."
+            )
+        return self._apply_to_coordinates(lambda c: c @ R.T + t, atoms=atoms)
+
+    def _require_nonperiodic(self, operation):
+        """Raise if this configuration is periodic."""
+        if self.periodicity != 0:
+            raise ValueError(
+                f"'{operation}' is only supported for non-periodic (molecular) "
+                f"systems; this configuration has periodicity {self.periodicity}."
+            )
+
+    def _resolve_point(self, point, atoms=None):
+        """Resolve a 'com'/'centroid'/'origin'/explicit point to an array."""
+        if isinstance(point, str):
+            if point == "com":
+                return self.center_of_mass(atoms=atoms, mass_weighted=True)
+            elif point == "centroid":
+                return self.center_of_mass(atoms=atoms, mass_weighted=False)
+            elif point == "origin":
+                return np.zeros(3)
+            else:
+                raise ValueError(
+                    f"Unknown reference point '{point}'; expected 'com', "
+                    "'centroid', 'origin', or a length-3 point."
+                )
+        return np.asarray(point, dtype=float).reshape(3)
+
+    def _apply_to_coordinates(self, func, atoms=None):
+        """Apply ``func`` to the Cartesian coordinates and store the result.
+
+        ``func`` takes and returns an (n, 3) array of Cartesian coordinates in Å.
+        If ``atoms`` is given, only those rows are passed through ``func`` and
+        updated; the rest are left unchanged.
+        """
+        xyz = self.atoms.get_coordinates(fractionals=False, as_array=True)
+        xyz = np.asarray(xyz, dtype=float)
+        if atoms is None:
+            xyz = func(xyz)
+        else:
+            idx = list(atoms)
+            xyz[idx] = func(xyz[idx])
+        self.atoms.set_coordinates(xyz, fractionals=False)
+        return self

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-"""Tests for System.create_combined_configuration()."""
+"""Tests for SystemDB.create_combined_system()."""
 
 import math
 
@@ -30,42 +30,51 @@ def _add_water(configuration):
 
 @pytest.fixture()
 def two_waters(empty_db):
-    """Two water monomers (in separate systems) plus an empty destination, one db."""
+    """A db with two water monomers in separate systems."""
     db = empty_db
     cA = db.create_system(name="A").create_configuration(name="A")
     _add_water(cA)
     cB = db.create_system(name="B").create_configuration(name="B")
     _add_water(cB)
-    dimers = db.create_system(name="dimers")
-    return dimers, cA, cB
+    return db, cA, cB
 
 
 def _n_bonds(configuration):
     return len(configuration.bonds.get_column_data("i"))
 
 
+def test_combine_creates_new_system(two_waters):
+    db, cA, cB = two_waters
+    n_systems = len(db.systems)
+    system = db.create_combined_system([cA, cB], name="dimer")
+    # A brand-new system was created and is distinct from the monomer systems.
+    assert len(db.systems) == n_systems + 1
+    assert system.id not in (cA.system.id, cB.system.id)
+    assert system.name == "dimer"
+
+
 def test_combine_counts(two_waters):
-    dimers, cA, cB = two_waters
-    new = dimers.create_combined_configuration([cA, cB])
+    db, cA, cB = two_waters
+    new = db.create_combined_system([cA, cB]).configuration
     assert new.n_atoms == cA.n_atoms + cB.n_atoms == 6
     assert _n_bonds(new) == _n_bonds(cA) + _n_bonds(cB) == 4
 
 
 def test_combine_atomic_numbers_concatenate(two_waters):
-    dimers, cA, cB = two_waters
-    new = dimers.create_combined_configuration([cA, cB])
+    db, cA, cB = two_waters
+    new = db.create_combined_system([cA, cB]).configuration
     assert list(new.atoms.atomic_numbers) == (
         list(cA.atoms.atomic_numbers) + list(cB.atoms.atomic_numbers)
     )
 
 
 def test_combine_places_with_transform(two_waters):
-    dimers, cA, cB = two_waters
+    db, cA, cB = two_waters
     shift = np.array([0.0, 0.0, 5.0])
     M = np.eye(4)
     M[:3, 3] = shift
 
-    new = dimers.create_combined_configuration([cA, cB], transforms=[None, M])
+    new = db.create_combined_system([cA, cB], transforms=[None, M]).configuration
 
     xyz = np.asarray(new.atoms.get_coordinates(fractionals=False, as_array=True))
     xyzA = np.asarray(cA.atoms.get_coordinates(fractionals=False, as_array=True))
@@ -76,10 +85,10 @@ def test_combine_places_with_transform(two_waters):
 
 
 def test_combine_with_rotation_preserves_monomer_geometry(two_waters):
-    dimers, cA, cB = two_waters
+    db, cA, cB = two_waters
     R = rotation_matrix_from_axis_angle([1.0, 2.0, 3.0], 57.0)
 
-    new = dimers.create_combined_configuration([cA, cB], transforms=[None, R])
+    new = db.create_combined_system([cA, cB], transforms=[None, R]).configuration
 
     xyz = np.asarray(new.atoms.get_coordinates(fractionals=False, as_array=True))
     xyzB = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
@@ -92,8 +101,8 @@ def test_combine_with_rotation_preserves_monomer_geometry(two_waters):
 
 
 def test_combine_bonds_stay_within_monomers(two_waters):
-    dimers, cA, cB = two_waters
-    new = dimers.create_combined_configuration([cA, cB])
+    db, cA, cB = two_waters
+    new = db.create_combined_system([cA, cB]).configuration
 
     ids = new.atoms.ids
     position = {atom_id: k for k, atom_id in enumerate(ids)}
@@ -108,12 +117,12 @@ def test_combine_bonds_stay_within_monomers(two_waters):
 
 
 def test_combine_does_not_modify_sources(two_waters):
-    dimers, cA, cB = two_waters
+    db, cA, cB = two_waters
     before = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
     M = np.eye(4)
     M[:3, 3] = [10.0, 0.0, 0.0]
 
-    dimers.create_combined_configuration([cA, cB], transforms=[None, M])
+    db.create_combined_system([cA, cB], transforms=[None, M])
 
     after = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
     assert np.allclose(before, after)
@@ -127,42 +136,59 @@ def test_combine_sums_charge(empty_db):
     cB = db.create_system(name="B").create_configuration(name="B")
     _add_water(cB)
     cB.charge = 2
-    dest = db.create_system(name="dest")
 
-    new = dest.create_combined_configuration([cA, cB])
+    new = db.create_combined_system([cA, cB]).configuration
     assert new.charge == 1
 
 
 def test_combine_three_configurations(two_waters):
     """A trimer: combining three monomers works (n-body assembly)."""
-    dimers, cA, cB = two_waters
-    cC = cA.system_db.create_system(name="C").create_configuration(name="C")
+    db, cA, cB = two_waters
+    cC = db.create_system(name="C").create_configuration(name="C")
     _add_water(cC)
 
-    new = dimers.create_combined_configuration([cA, cB, cC])
+    new = db.create_combined_system([cA, cB, cC]).configuration
     assert new.n_atoms == 9
     assert _n_bonds(new) == 6
 
 
+def test_poses_are_conformers_sharing_one_atomset(two_waters):
+    """The intended workflow: combine once, then copy_configuration for poses."""
+    db, cA, cB = two_waters
+    system = db.create_combined_system([cA, cB], name="dimer")
+    base = system.configuration
+
+    # Add several poses as conformers (shared atomset, coordinates only).
+    B_idx = list(range(cA.n_atoms, cA.n_atoms + cB.n_atoms))
+    atomsets = {base.atomset}
+    for sep in (3.0, 4.0, 5.0):
+        pose = system.copy_configuration(base, name=f"{sep} A")
+        pose.translate([0.0, 0.0, sep], atoms=B_idx)
+        atomsets.add(pose.atomset)
+
+    # All four configurations live in one system and share a single atomset.
+    assert len(system.configurations) == 4
+    assert len(atomsets) == 1
+
+
 def test_combine_rejects_periodic(two_waters):
-    dimers, cA, cB = two_waters
-    periodic = cA.system_db.create_system(name="P").create_configuration(name="P")
+    db, cA, cB = two_waters
+    periodic = db.create_system(name="P").create_configuration(name="P")
     periodic.periodicity = 3
     periodic.coordinate_system = "fractional"
     periodic.cell.parameters = [10.0, 10.0, 10.0, 90.0, 90.0, 90.0]
     periodic.atoms.append(x=[0.0], y=[0.0], z=[0.0], symbol=["Ar"])
 
     with pytest.raises(ValueError):
-        dimers.create_combined_configuration([cA, periodic])
+        db.create_combined_system([cA, periodic])
 
 
 def test_combine_transform_length_mismatch_raises(two_waters):
-    dimers, cA, cB = two_waters
+    db, cA, cB = two_waters
     with pytest.raises(ValueError):
-        dimers.create_combined_configuration([cA, cB], transforms=[None])
+        db.create_combined_system([cA, cB], transforms=[None])
 
 
-def test_combine_empty_raises(two_waters):
-    dimers, cA, cB = two_waters
+def test_combine_empty_raises(empty_db):
     with pytest.raises(ValueError):
-        dimers.create_combined_configuration([])
+        empty_db.create_combined_system([])

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for System.create_combined_configuration()."""
+
+import math
+
+import numpy as np
+import pytest
+
+from molsystem import rotation_matrix_from_axis_angle
+
+
+def _add_water(configuration):
+    """Populate a configuration with a single TIP3P-geometry water."""
+    r0 = 0.9572
+    theta0 = 104.52
+    x = r0 * math.sin(math.radians(theta0 / 2))
+    z = r0 * math.cos(math.radians(theta0 / 2))
+
+    X = [0.0, x, -x]
+    Y = [0.0, 0.0, 0.0]
+    Z = [0.0, z, z]
+    atno = [8, 1, 1]
+
+    ids = configuration.atoms.append(x=X, y=Y, z=Z, atno=atno)
+    configuration.bonds.append(i=[ids[0], ids[0]], j=[ids[1], ids[2]], bondorder=[1, 1])
+    return configuration
+
+
+@pytest.fixture()
+def two_waters(empty_db):
+    """Two water monomers (in separate systems) plus an empty destination, one db."""
+    db = empty_db
+    cA = db.create_system(name="A").create_configuration(name="A")
+    _add_water(cA)
+    cB = db.create_system(name="B").create_configuration(name="B")
+    _add_water(cB)
+    dimers = db.create_system(name="dimers")
+    return dimers, cA, cB
+
+
+def _n_bonds(configuration):
+    return len(configuration.bonds.get_column_data("i"))
+
+
+def test_combine_counts(two_waters):
+    dimers, cA, cB = two_waters
+    new = dimers.create_combined_configuration([cA, cB])
+    assert new.n_atoms == cA.n_atoms + cB.n_atoms == 6
+    assert _n_bonds(new) == _n_bonds(cA) + _n_bonds(cB) == 4
+
+
+def test_combine_atomic_numbers_concatenate(two_waters):
+    dimers, cA, cB = two_waters
+    new = dimers.create_combined_configuration([cA, cB])
+    assert list(new.atoms.atomic_numbers) == (
+        list(cA.atoms.atomic_numbers) + list(cB.atoms.atomic_numbers)
+    )
+
+
+def test_combine_places_with_transform(two_waters):
+    dimers, cA, cB = two_waters
+    shift = np.array([0.0, 0.0, 5.0])
+    M = np.eye(4)
+    M[:3, 3] = shift
+
+    new = dimers.create_combined_configuration([cA, cB], transforms=[None, M])
+
+    xyz = np.asarray(new.atoms.get_coordinates(fractionals=False, as_array=True))
+    xyzA = np.asarray(cA.atoms.get_coordinates(fractionals=False, as_array=True))
+    xyzB = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
+
+    assert np.allclose(xyz[:3], xyzA)
+    assert np.allclose(xyz[3:], xyzB + shift)
+
+
+def test_combine_with_rotation_preserves_monomer_geometry(two_waters):
+    dimers, cA, cB = two_waters
+    R = rotation_matrix_from_axis_angle([1.0, 2.0, 3.0], 57.0)
+
+    new = dimers.create_combined_configuration([cA, cB], transforms=[None, R])
+
+    xyz = np.asarray(new.atoms.get_coordinates(fractionals=False, as_array=True))
+    xyzB = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
+
+    # Internal O-H distances of monomer B are unchanged by the rotation.
+    def oh(coords):
+        return np.linalg.norm(coords[1:] - coords[0], axis=1)
+
+    assert np.allclose(sorted(oh(xyz[3:])), sorted(oh(xyzB)))
+
+
+def test_combine_bonds_stay_within_monomers(two_waters):
+    dimers, cA, cB = two_waters
+    new = dimers.create_combined_configuration([cA, cB])
+
+    ids = new.atoms.ids
+    position = {atom_id: k for k, atom_id in enumerate(ids)}
+    nA = cA.n_atoms
+
+    i_ids = new.bonds.get_column_data("i")
+    j_ids = new.bonds.get_column_data("j")
+    assert len(i_ids) == 4
+    for a, b in zip(i_ids, j_ids):
+        # Both ends of every bond belong to the same monomer block.
+        assert (position[a] < nA) == (position[b] < nA)
+
+
+def test_combine_does_not_modify_sources(two_waters):
+    dimers, cA, cB = two_waters
+    before = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
+    M = np.eye(4)
+    M[:3, 3] = [10.0, 0.0, 0.0]
+
+    dimers.create_combined_configuration([cA, cB], transforms=[None, M])
+
+    after = np.asarray(cB.atoms.get_coordinates(fractionals=False, as_array=True))
+    assert np.allclose(before, after)
+
+
+def test_combine_sums_charge(empty_db):
+    db = empty_db
+    cA = db.create_system(name="A").create_configuration(name="A")
+    _add_water(cA)
+    cA.charge = -1
+    cB = db.create_system(name="B").create_configuration(name="B")
+    _add_water(cB)
+    cB.charge = 2
+    dest = db.create_system(name="dest")
+
+    new = dest.create_combined_configuration([cA, cB])
+    assert new.charge == 1
+
+
+def test_combine_three_configurations(two_waters):
+    """A trimer: combining three monomers works (n-body assembly)."""
+    dimers, cA, cB = two_waters
+    cC = cA.system_db.create_system(name="C").create_configuration(name="C")
+    _add_water(cC)
+
+    new = dimers.create_combined_configuration([cA, cB, cC])
+    assert new.n_atoms == 9
+    assert _n_bonds(new) == 6
+
+
+def test_combine_rejects_periodic(two_waters):
+    dimers, cA, cB = two_waters
+    periodic = cA.system_db.create_system(name="P").create_configuration(name="P")
+    periodic.periodicity = 3
+    periodic.coordinate_system = "fractional"
+    periodic.cell.parameters = [10.0, 10.0, 10.0, 90.0, 90.0, 90.0]
+    periodic.atoms.append(x=[0.0], y=[0.0], z=[0.0], symbol=["Ar"])
+
+    with pytest.raises(ValueError):
+        dimers.create_combined_configuration([cA, periodic])
+
+
+def test_combine_transform_length_mismatch_raises(two_waters):
+    dimers, cA, cB = two_waters
+    with pytest.raises(ValueError):
+        dimers.create_combined_configuration([cA, cB], transforms=[None])
+
+
+def test_combine_empty_raises(two_waters):
+    dimers, cA, cB = two_waters
+    with pytest.raises(ValueError):
+        dimers.create_combined_configuration([])

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""Tests for the rigid-body transforms on a configuration."""
+
+import math
+
+import numpy as np
+import pytest
+
+from molsystem import (
+    random_rotation_matrix,
+    rotation_matrix_from_axis_angle,
+    rotation_matrix_from_quaternion,
+)
+
+
+def _distance_matrix(xyz):
+    """Pairwise distance matrix, for checking rigid-body invariance."""
+    diff = xyz[:, np.newaxis, :] - xyz[np.newaxis, :, :]
+    return np.linalg.norm(diff, axis=-1)
+
+
+# --------------------------------------------------------------------------- #
+# Rotation-matrix helpers
+# --------------------------------------------------------------------------- #
+
+
+def test_axis_angle_90_about_z():
+    """90 degrees about z maps (1, 0, 0) -> (0, 1, 0)."""
+    R = rotation_matrix_from_axis_angle([0, 0, 1], 90)
+    rotated = R @ np.array([1.0, 0.0, 0.0])
+    assert np.allclose(rotated, [0.0, 1.0, 0.0], atol=1.0e-12)
+
+
+def test_axis_angle_radians():
+    """Degrees=False is honored."""
+    R = rotation_matrix_from_axis_angle([0, 0, 1], math.pi / 2, degrees=False)
+    rotated = R @ np.array([1.0, 0.0, 0.0])
+    assert np.allclose(rotated, [0.0, 1.0, 0.0], atol=1.0e-12)
+
+
+def test_axis_angle_unnormalized_axis():
+    """The axis need not be normalized."""
+    R1 = rotation_matrix_from_axis_angle([0, 0, 1], 37)
+    R2 = rotation_matrix_from_axis_angle([0, 0, 5], 37)
+    assert np.allclose(R1, R2)
+
+
+def test_axis_angle_zero_axis_raises():
+    with pytest.raises(ValueError):
+        rotation_matrix_from_axis_angle([0, 0, 0], 90)
+
+
+def test_quaternion_identity():
+    """The identity quaternion gives the identity matrix."""
+    R = rotation_matrix_from_quaternion([1, 0, 0, 0])
+    assert np.allclose(R, np.eye(3))
+
+
+def test_quaternion_is_proper_rotation():
+    R = rotation_matrix_from_quaternion([0.5, 0.5, 0.5, 0.5])
+    assert np.allclose(R @ R.T, np.eye(3), atol=1.0e-12)
+    assert math.isclose(np.linalg.det(R), 1.0, abs_tol=1.0e-12)
+
+
+def test_random_rotation_is_proper_and_reproducible():
+    rng = np.random.default_rng(42)
+    R = random_rotation_matrix(rng)
+    assert np.allclose(R @ R.T, np.eye(3), atol=1.0e-12)
+    assert math.isclose(np.linalg.det(R), 1.0, abs_tol=1.0e-12)
+    # Same seed -> same matrix
+    assert np.allclose(R, random_rotation_matrix(np.random.default_rng(42)))
+
+
+# --------------------------------------------------------------------------- #
+# center_of_mass / centroid
+# --------------------------------------------------------------------------- #
+
+
+def test_center_of_mass_vs_centroid(H2O):
+    com = H2O.center_of_mass()
+    centroid = H2O.centroid()
+    # COM is pulled toward the heavy oxygen at the origin, so it sits below
+    # the geometric centroid in z.
+    assert com[2] < centroid[2]
+    # By symmetry both lie on the z axis.
+    assert np.allclose(com[:2], [0.0, 0.0], atol=1.0e-12)
+    assert np.allclose(centroid[:2], [0.0, 0.0], atol=1.0e-12)
+
+
+def test_centroid_is_mean(H2O):
+    xyz = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    assert np.allclose(H2O.centroid(), xyz.mean(axis=0))
+
+
+def test_center_of_mass_subset(AceticAcid):
+    """COM of a subset equals the COM computed by hand for those atoms."""
+    xyz = np.asarray(AceticAcid.atoms.get_coordinates(fractionals=False, as_array=True))
+    masses = np.asarray(AceticAcid.atoms.atomic_masses)
+    idx = [0, 4, 5]  # the two carbons and an oxygen
+    expected = (masses[idx, np.newaxis] * xyz[idx]).sum(axis=0) / masses[idx].sum()
+    assert np.allclose(AceticAcid.center_of_mass(atoms=idx), expected)
+
+
+# --------------------------------------------------------------------------- #
+# translate
+# --------------------------------------------------------------------------- #
+
+
+def test_translate_shifts_com(AceticAcid):
+    com0 = AceticAcid.center_of_mass()
+    d = np.array([1.0, -2.0, 3.5])
+    AceticAcid.translate(d)
+    assert np.allclose(AceticAcid.center_of_mass(), com0 + d)
+
+
+def test_translate_preserves_internal_geometry(AceticAcid):
+    d0 = _distance_matrix(
+        np.asarray(AceticAcid.atoms.get_coordinates(fractionals=False, as_array=True))
+    )
+    AceticAcid.translate([3.0, 0.0, 0.0])
+    d1 = _distance_matrix(
+        np.asarray(AceticAcid.atoms.get_coordinates(fractionals=False, as_array=True))
+    )
+    assert np.allclose(d0, d1)
+
+
+def test_translate_returns_self(AceticAcid):
+    assert AceticAcid.translate([0.0, 0.0, 1.0]) is AceticAcid
+
+
+def test_translate_subset(H2O):
+    """Translating only the oxygen moves just that atom."""
+    xyz0 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    H2O.translate([0.0, 0.0, 10.0], atoms=[0])
+    xyz1 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    assert np.allclose(xyz1[0], xyz0[0] + [0.0, 0.0, 10.0])
+    assert np.allclose(xyz1[1:], xyz0[1:])
+
+
+# --------------------------------------------------------------------------- #
+# rotate
+# --------------------------------------------------------------------------- #
+
+
+def test_rotate_about_com_preserves_com_and_shape(AceticAcid):
+    com0 = AceticAcid.center_of_mass()
+    d0 = _distance_matrix(
+        np.asarray(AceticAcid.atoms.get_coordinates(fractionals=False, as_array=True))
+    )
+    R = random_rotation_matrix(np.random.default_rng(7))
+    AceticAcid.rotate(R, about="com")
+    assert np.allclose(AceticAcid.center_of_mass(), com0)
+    d1 = _distance_matrix(
+        np.asarray(AceticAcid.atoms.get_coordinates(fractionals=False, as_array=True))
+    )
+    assert np.allclose(d0, d1)
+
+
+def test_rotate_about_origin_known(H2O):
+    """90 degrees about z, about the origin: (x, 0, z) -> (0, x, z)."""
+    xyz0 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    R = rotation_matrix_from_axis_angle([0, 0, 1], 90)
+    H2O.rotate(R, about="origin")
+    xyz1 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    expected = xyz0 @ R.T
+    assert np.allclose(xyz1, expected)
+    # Oxygen sits at the origin, so it is unmoved.
+    assert np.allclose(xyz1[0], [0.0, 0.0, 0.0], atol=1.0e-12)
+
+
+def test_rotate_accepts_4x4(H2O):
+    """A 4x4 matrix uses only its rotation block in rotate()."""
+    R = rotation_matrix_from_axis_angle([1, 1, 0], 33)
+    M = np.eye(4)
+    M[:3, :3] = R
+    M[:3, 3] = [9.0, 9.0, 9.0]  # translation block must be ignored by rotate()
+    a = H2O.center_of_mass()
+    H2O.rotate(M, about="com")
+    # rotation about the COM leaves the COM fixed; translation block ignored
+    assert np.allclose(H2O.center_of_mass(), a)
+
+
+def test_rotate_bad_shape_raises(H2O):
+    with pytest.raises(ValueError):
+        H2O.rotate(np.ones((2, 2)))
+
+
+def test_rotate_bad_about_raises(H2O):
+    with pytest.raises(ValueError):
+        H2O.rotate(np.eye(3), about="nonsense")
+
+
+# --------------------------------------------------------------------------- #
+# transform (RDKit TransformMol convention: p' = R @ p + t)
+# --------------------------------------------------------------------------- #
+
+
+def test_transform_matches_rotate_then_translate(AceticAcid, H2O):
+    """A 4x4 transform equals rotating about the origin then translating."""
+    R = rotation_matrix_from_axis_angle([0, 1, 0], 50)
+    t = np.array([2.0, -1.0, 0.5])
+
+    M = np.eye(4)
+    M[:3, :3] = R
+    M[:3, 3] = t
+
+    # H2O and AceticAcid fixtures are independent configurations; build the
+    # reference by hand from H2O's coordinates.
+    xyz0 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    expected = xyz0 @ R.T + t
+
+    H2O.transform(M)
+    xyz1 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    assert np.allclose(xyz1, expected)
+
+
+def test_transform_3x3_is_pure_rotation(H2O):
+    xyz0 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    R = rotation_matrix_from_axis_angle([0, 0, 1], 90)
+    H2O.transform(R)
+    xyz1 = np.asarray(H2O.atoms.get_coordinates(fractionals=False, as_array=True))
+    assert np.allclose(xyz1, xyz0 @ R.T)
+
+
+def test_transform_bad_shape_raises(H2O):
+    with pytest.raises(ValueError):
+        H2O.transform(np.ones((2, 3)))
+
+
+# --------------------------------------------------------------------------- #
+# Periodic systems are disallowed for all transforms
+# --------------------------------------------------------------------------- #
+
+
+def test_translate_rejects_periodic(copper):
+    with pytest.raises(ValueError):
+        copper.translate([1.0, 0.0, 0.0])
+
+
+def test_rotate_rejects_periodic(copper):
+    with pytest.raises(ValueError):
+        copper.rotate(np.eye(3))
+
+
+def test_transform_rejects_periodic(copper):
+    with pytest.raises(ValueError):
+        copper.transform(np.eye(3))


### PR DESCRIPTION
* Added rigid-body transforms for a (molecular) configuration: the center of mass or geometric centroid, and in-place translate, rotate (about the center of mass, centroid, origin, or an explicit point), and a general affine transform. Helpers are provided to build rotation matrices from an axis and angle, from a quaternion, or as a uniformly random orientation.
* Added a method to combine two or more configurations into a new system -- for example assembling a dimer or larger cluster from separate molecules -- optionally rotating and displacing each molecule into place as it is added. Combining always makes a new system, so further configurations added to it are conformers with the same atoms and bonds.
* These operations are supported for molecular (non-periodic) systems.